### PR TITLE
Added support for lumi.sensor_ht

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ function registerSupportedDevices() {
     XiaomiContactSensor
   );
   registerAccessoryClass('Xiaomi', ['GZCGQ01LM'], XiaomiLightIntensitySensor);
-  registerAccessoryClass('LUMI', ['lumi.weather', 'lumi.sensor_ht.agl02'], TempHumiSensor);
+  registerAccessoryClass('LUMI', ['lumi.weather', 'lumi.sensor_ht.agl02', 'lumi.sensor_ht'], TempHumiSensor);
   registerAccessoryClass(
     'LUMI',
     ['lumi.sensor_magnet', 'lumi.sensor_magnet.aq2'],


### PR DESCRIPTION
Added support for a possible variation on the 'lumi.sensor_ht.agl02' my sensor reported itself as 'lumi.sensor_ht' so I have added it here. All functions work as intended